### PR TITLE
Fix rare ConcurrentModificationException in quit handler

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -212,7 +212,8 @@ public class EssentialsPlayerListener implements Listener {
             user.getBase().getOpenInventory().getTopInventory().clear();
         }
 
-        for (HumanEntity viewer : user.getBase().getInventory().getViewers()) {
+        ArrayList<HumanEntity> viewers = new ArrayList<>(user.getBase().getInventory().getViewers());
+        for (HumanEntity viewer : viewers) {
             if (viewer instanceof Player) {
                 User uviewer = ess.getUser((Player) viewer);
                 if (uviewer.isInvSee()) {


### PR DESCRIPTION
Copies the list of viewers before iterating over it to fix a rare CME that is *sometimes* thrown. It's not clear *why* this broke - Spigot seems to have changed behaviour in late 1.15 or 1.16?